### PR TITLE
feat: Configure containerd registry mirrors for Nexus Docker proxies

### DIFF
--- a/cluster-template-home.yaml
+++ b/cluster-template-home.yaml
@@ -31,6 +31,8 @@ patches:
     file: ./patches/machine-kubelet.yaml
   - name: kernel-storage
     file: ./patches/kernel-iscsi.yaml
+  - name: machine-registries
+    file: ./patches/machine-registries.yaml
   # 🛑 DO NOT inject the "bgp=enable" label here—only Workers run the BGP speaker!
   # - name: node-labels
   #   inline:
@@ -80,6 +82,8 @@ patches:
     file: ./patches/kernel-iscsi.yaml
   - name: kernel-amdgpu
     file: ./patches/kernel-amdgpu.yaml
+  - name: machine-registries
+    file: ./patches/machine-registries.yaml
   # ✅ Correct: inject the "bgp=enable" node label only on worker nodes (eligible for BGP speaking).
   - name: node-labels
     inline:

--- a/patches/machine-registries.yaml
+++ b/patches/machine-registries.yaml
@@ -1,20 +1,41 @@
-# This enables image caching for the listed remote registries. Saves bandwidth and speeds up deployments. 
-# Registries are hosted in Container Station on the QNAP NAS.
+# Containerd registry mirrors for Nexus Docker proxies
+# Routes image pulls through Nexus cache with upstream fallback for bootstrap
+# See: https://github.com/erauner12/omni/issues/2
 machine:
   registries:
     mirrors:
+      # Docker Hub
       docker.io:
         endpoints:
-        - http://192.168.1.3:5000
-      gcr.io:
-        endpoints:
-        - http://192.168.1.3:5002
+          - https://docker-hub.nexus.erauner.dev  # Nexus cache
+          - https://registry-1.docker.io          # Upstream fallback
+
+      # GitHub Container Registry
       ghcr.io:
         endpoints:
-        - http://192.168.1.3:5003
-      registry.k8s.io:
-        endpoints:
-        - http://192.168.1.3:5001
+          - https://docker-ghcr.nexus.erauner.dev
+          - https://ghcr.io
+
+      # Quay.io
       quay.io:
         endpoints:
-        - http://192.168.1.3:5004
+          - https://docker-quay.nexus.erauner.dev
+          - https://quay.io
+
+      # LinuxServer.io
+      lscr.io:
+        endpoints:
+          - https://docker-lscr.nexus.erauner.dev
+          - https://lscr.io
+
+      # Kubernetes registry
+      registry.k8s.io:
+        endpoints:
+          - https://docker-k8s.nexus.erauner.dev
+          - https://registry.k8s.io
+
+      # AWS ECR Public
+      public.ecr.aws:
+        endpoints:
+          - https://docker-ecr.nexus.erauner.dev
+          - https://public.ecr.aws


### PR DESCRIPTION
## Summary
Configure Talos containerd to route image pulls through Nexus Docker proxies, enabling cached image distribution across the cluster.

Closes #2

## Changes
- **`patches/machine-registries.yaml`**: Updated to use Nexus proxies instead of old QNAP Container Station endpoints
- **`cluster-template-home.yaml`**: Added `machine-registries` patch to both ControlPlane and Workers

## Registry Mappings
| Registry | Nexus Proxy | Fallback |
|----------|-------------|----------|
| docker.io | docker-hub.nexus.erauner.dev | registry-1.docker.io |
| ghcr.io | docker-ghcr.nexus.erauner.dev | ghcr.io |
| quay.io | docker-quay.nexus.erauner.dev | quay.io |
| lscr.io | docker-lscr.nexus.erauner.dev | lscr.io |
| registry.k8s.io | docker-k8s.nexus.erauner.dev | registry.k8s.io |
| public.ecr.aws | docker-ecr.nexus.erauner.dev | public.ecr.aws |

## Why Fallbacks?
Each mirror includes the upstream registry as a fallback for:
- Fresh cluster bootstrap (Nexus not yet running)
- New node joining (Nexus temporarily unreachable)
- Nexus pod rescheduling

## Testing
After merge, apply via Omni and verify:
1. Node config shows new registry mirrors
2. Image pulls route through Nexus (check Nexus Docker component counts)
3. Fallback works if Nexus is unavailable

## Related
- [homelab-k8s#976](https://github.com/erauner/homelab-k8s/pull/976) - Nexus Docker proxy deployment
- [homelab-k8s#978](https://github.com/erauner/homelab-k8s/pull/978) - Failed app-level migration (this is the fix)