### PR TITLE
feat(cilium): Enable Prometheus metrics endpoints

### DIFF
--- a/patches/cilium-install-home.yaml
+++ b/patches/cilium-install-home.yaml
@@ -114,12 +114,29 @@ cluster:
                 - NET_ADMIN
                 - SYS_ADMIN
                 - SYS_RESOURCE
+          # ------------------------------------------------------------------
+          # Prometheus Metrics - Enable endpoints only
+          # ServiceMonitors are managed by GitOps (homelab-k8s/infrastructure/cilium-config)
+          # ------------------------------------------------------------------
+          prometheus:
+            enabled: true
+          operator:
+            prometheus:
+              enabled: true
           hubble:
             enabled: true
             relay:
               enabled: true
             ui:
               enabled: true
+            metrics:
+              enabled:
+                - dns
+                - drop
+                - tcp
+                - flow
+                - icmp
+                - http
           gatewayAPI:
             enabled: false
             secretsNamespace:


### PR DESCRIPTION
## Summary

Enable Prometheus metrics endpoints for Cilium components so they can be scraped by Prometheus.

**Changes to `patches/cilium-install-home.yaml`:**
- `prometheus.enabled: true` - Agent metrics on port 9962
- `operator.prometheus.enabled: true` - Operator metrics on port 9963  
- `hubble.metrics.enabled: [dns, drop, tcp, flow, icmp, http]` - Hubble observability metrics

## Architecture

ServiceMonitors are NOT created by this PR. They are managed by GitOps in the homelab-k8s repo, following the pattern established by `longhorn-config`:

| Layer | Omni | GitOps (homelab-k8s) |
|-------|------|---------------------|
| Install | ✅ | - |
| Enable metrics ports | ✅ | - |
| Create ServiceMonitors | - | ✅ |

## Dependencies

**Companion PR:** erauner/homelab-k8s#1220

## Test plan

- [ ] Merge this PR
- [ ] Sync cluster via Omni
- [ ] Upgrade Cilium: `cilium upgrade -f /tmp/cilium-values.yaml --version 1.17.5`
- [ ] Verify metrics endpoints respond:
  ```bash
  kubectl exec -n cilium <agent-pod> -- curl localhost:9962/metrics
  kubectl exec -n cilium <operator-pod> -- curl localhost:9963/metrics
  ```
- [ ] Merge homelab-k8s PR to deploy PodMonitors
- [ ] Verify in Prometheus targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)